### PR TITLE
[FIX] getLoginedUser, 중복 import 제거

### DIFF
--- a/Puhaha/Puhaha/Controllers/MainViewController.swift
+++ b/Puhaha/Puhaha/Controllers/MainViewController.swift
@@ -6,8 +6,6 @@
 //
 
 import UIKit
-import FirebaseStorage
-import FirebaseFirestore
 
 import FirebaseFirestore
 import FirebaseStorage
@@ -189,7 +187,7 @@ class MainViewController: UIViewController {
     }
     
     private func getLoginedUser() {
-        firestoreManager.getLoginedUser(userEmail: loginedUserEmail) { [self] in
+        firestoreManager.getSignInUser(userEmail: loginedUserEmail) { [self] in
             loginedUser = firestoreManager.loginedUser
             emptyMealCardView.setButtonImage(toolImage: loginedUser.getToolImage())
             emptyMealCardView.reloadInputViews()

--- a/Puhaha/Puhaha/Controllers/MealDetailViewController.swift
+++ b/Puhaha/Puhaha/Controllers/MealDetailViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import FirebaseStorage
 
 import FirebaseStorage
 


### PR DESCRIPTION
 ## ✅ 구현/변경 사항 및 이유

- merge 제대로 된 건지 확인하려고 + 수정

 ## ✅ PR Point

1) merge 직전에 Xcode, Terminal, 크라켄, 데스크탑 등등 Xcode로 컨플릭트 해결한 작업이 안올라가서 마비되었습니다.. . 
-> git hub 상에서 웹으로 다시 수정하니, main에 merge는 되었는데.
: 메인이랑 충돌나는 부분 외에도, 더 수정해야하는 부분(함수명 바꾸기)이 있어서 급하게 브랜치를 다시 팠습니다.

2) Xcode 상에서 컨플릭 수정했을 때는, 잘 돌아갔는데, mainTabBar 화면에서 계란 이미지가 안뜨더라고요?!
(+ 버튼도 사라지고, 계란 있어야 할 부분을 클릭하면 사진 업로드 모달은 뜨는데, 단순히 이미지가 없던 상태였습니다.)
: 근데 git-hub에서 수정하고, 다시 브랜치 파서 받아오니, 이미지도 잘 뜹니다! 👍

3) 서버 연결도 잘 되어있는지 폰으로 돌려서 파이어베이스 한번 더 확인하고 싶었는데, 

No profile for team 'D9CAJN27UH' matching 'WhatDidYouEat' found: Xcode couldn't find any provisioning profiles matching 'D9CAJN27UH/WhatDidYouEat'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor.

기기연결 에러가 나네요 ^_^;; (provisioning profiles .. ?)
제대로 연결되면 서버 연결 코드도 잘 작동하는지 확인해주시면 감사하겠습니다. 🙇‍♀️🙇‍♀️
+ 기기연결 없이 그냥 아이폰 13으로 돌리면, 오류없이 빌드되고 잘 실행됩니다. 

 ## ✅ 참고 사항

<img width="454" alt="스크린샷 2022-08-09 오후 10 41 05" src="https://user-images.githubusercontent.com/82718756/183666327-21b9258a-29ac-4287-82f1-81f66b687fc4.png">

